### PR TITLE
fixed some Speakers name typo and wrong html tags

### DIFF
--- a/source/program.html.erb
+++ b/source/program.html.erb
@@ -63,8 +63,8 @@ menu:
       <tr>
         <td>13:30</td>
         <td>14:00</td>
-        <td><div class="speaker">案浦 浩二 Koji Annour</div>翻訳ゆらぎや関連用語をグラフで視覚化し翻訳範囲を共有する</td>
-        <td><div class="speaker">Linjie L</div>LibreOffice: Educational practice in China</td>
+        <td><div class="speaker">案浦 浩二 Koji Annoura</div>翻訳ゆらぎや関連用語をグラフで視覚化し翻訳範囲を共有する</td>
+        <td><div class="speaker">Linjie Lv</div>LibreOffice: Educational practice in China</td>
         <td><div class="speaker">Wen-Ke Huang</div>Grow out of nothing, the first successful experience about importing LibreOffice into state-owned company (CPC corporation, Taiwan) since 2016.</td>
       </tr>
       <tr>
@@ -95,7 +95,7 @@ menu:
         <td>15:40</td>
         <td>16:10</td>
         <td><div class="speaker">荒川 雄介 Yusuke Arakawa</div>ParseJSONを作るぞ</td>
-        <td><div class="speaker">DaeHyun Sung(성대현/成大鉉/ソン・デヒョン)</div>CJK issues (based on Korean Language and</div>Ideographs[漢字, Chinese characters]) on LibreOffice</td>
+        <td><div class="speaker">DaeHyun Sung<br />(성대현/成大鉉/ソン・デヒョン)</div>CJK issues (based on Korean Language and Ideographs[漢字, Chinese characters]) on LibreOffice</td>
         <td><div class="speaker">Tomaž Vajngerl</div>Collabora Online and what is new in latest version – 4.0</td>
       </tr>
       <tr>


### PR DESCRIPTION
1. fixed some Speakers name typo
`案浦 浩二 Koji Annour` to `案浦 浩二 Koji Annoura`
`Linjie L` to `Linjie Lv`

2. fixed wrong html tags & add spacing
`<td><div class="speaker">DaeHyun Sung(성대현/成大鉉/ソン・デヒョン)</div>CJK issues (based on Korean Language and</div>Ideographs[漢字, Chinese characters]) on LibreOffice</td>`
to
`<td><div class="speaker">DaeHyun Sung<br />(성대현/成大鉉/ソン・デヒョン)</div>CJK issues (based on Korean Language and Ideographs[漢字, Chinese characters]) on LibreOffice</td>`