### PR TITLE
Fixed the Korean typo (서광,seogwang)

### DIFF
--- a/source/talk.html.erb
+++ b/source/talk.html.erb
@@ -155,7 +155,7 @@ menu:
       in South Korea and North Korea.
       </p>
       <p>
-      and I'll introduce North Korea Linux distribution and seoguang(서광) Office
+      and I'll introduce North Korea Linux distribution and seogwang(서광) Office
       suite based on Open office.
       </p>
     </section>


### PR DESCRIPTION
I confused to write North Korea's Office Suite english transliterated name,  `seoguang`.

That's Corrected name is `seogwang`.

I fixed the Korean typo `seoguang` to `seogwang`